### PR TITLE
Plane

### DIFF
--- a/Source/VoxelActors/SimpleVoxel.cpp
+++ b/Source/VoxelActors/SimpleVoxel.cpp
@@ -10,12 +10,31 @@ ASimpleVoxel::ASimpleVoxel()
 
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
-	verts = { FVector(0,0,0), FVector(10,0,0), FVector(10,10,0), FVector(0,10,0), FVector(0,0,10), FVector(10,0,10), FVector(10,10,10), FVector(0,10,10) };
+
+	FVector trans = FVector(0);
+
+	//verts = { FVector(0,0,0), FVector(10,0,0), FVector(10,10,0), FVector(0,10,0), FVector(0,0,10), FVector(10,0,10), FVector(10,10,10), FVector(0,10,10) };
 	//verts = { FVector(0,0,0), FVector(10,0,0), FVector(5,5,0), FVector(0,0,10), FVector(10,0,10), FVector(5,5,10) };
 	//verts = { FVector(0,-20,0), FVector(-19,-6,0), FVector(-12,16,0), FVector(12,16,0), FVector(19,-6,0), FVector(0,-20,20), FVector(-19,-6,20), FVector(-12,16,20), FVector(12,16,20), FVector(19,-6,20) };
-	//verts = { 20 * FVector(1,1,1), 20 * FVector(1,1,-1), 20 * FVector(1,-1,1), 20 * FVector(1,-1,-1), 20 * FVector(-1,1,1), 20 * FVector(-1,1,-1), 20 * FVector(-1,-1,1), 20 * FVector(-1,-1,-1), 20 * FVector(0,1.618,1 / 1.618), 20 * FVector(0,1.618,-1 / 1.618), 20 * FVector(0,-1.618,1 / 1.618),20 * FVector(0,-1.618,-1 / 1.618),20 * FVector(1 / 1.618,0,1.618), 20 * FVector(1 / 1.618,0,-1.618),20 * FVector(-1 / 1.618,0,1.618),20 * FVector(-1 / 1.618,0,-1.618),20 * FVector(1.618,1 / 1.618,0),20 * FVector(1.618,-1 / 1.618,0),20 * FVector(-1.618,1 / 1.618,0),20 * FVector(-1.618,-1 / 1.618, 0) };
+	verts = { 20 * FVector(1,1,1), 20 * FVector(1,1,-1), 20 * FVector(1,-1,1), 20 * FVector(1,-1,-1), 20 * FVector(-1,1,1), 20 * FVector(-1,1,-1), 20 * FVector(-1,-1,1), 20 * FVector(-1,-1,-1), 20 * FVector(0,1.618,1 / 1.618), 20 * FVector(0,1.618,-1 / 1.618), 20 * FVector(0,-1.618,1 / 1.618),20 * FVector(0,-1.618,-1 / 1.618),20 * FVector(1 / 1.618,0,1.618), 20 * FVector(1 / 1.618,0,-1.618),20 * FVector(-1 / 1.618,0,1.618),20 * FVector(-1 / 1.618,0,-1.618),20 * FVector(1.618,1 / 1.618,0),20 * FVector(1.618,-1 / 1.618,0),20 * FVector(-1.618,1 / 1.618,0),20 * FVector(-1.618,-1 / 1.618, 0) };
 
-	//verts.Sort();
+
+	for (FVector v : verts) {
+		if (v.X < trans.X)
+			trans.X = v.X;
+		if (v.Y < trans.Y)
+			trans.Y = v.Y;
+		if (v.Z < trans.Z)
+			trans.Z = v.Z;
+	}
+
+	verts.Sort([trans](const FVector A,  const FVector B){
+		return (A-trans).Size() < (B-trans).Size();
+	});
+
+	for (FVector v : verts) {
+		sort_verts.Emplace(v - trans);
+	}
 
 	num_v = verts.Num();
 	mesh_made = false;
@@ -34,88 +53,9 @@ ASimpleVoxel::ASimpleVoxel()
 	mesh->SetMaterial(0, MyMaterial);
 }
 
-bool ASimpleVoxel::Overlap(Seg_3 seg1, Seg_3 seg2)
-{
-	FVector int1, int2;
-	FMath::SegmentDistToSegmentSafe(seg1.vert[0], seg1.vert[1], seg2.vert[0], seg2.vert[1], int1, int2);
-
-	if ((int1 - int2).Size() > 0.00001)
-		return false;
-	if (int1 == seg1.vert[0] || int1 == seg1.vert[1])
-		return false;
-	if (int2 == seg2.vert[0] || int2 == seg2.vert[1])
-		return false;
-
-	return true;
-}
-
-void ASimpleVoxel::ResolveOverlap(int a, int b)
-{
-	int idx[2] = { a, b };
-	bool safe_s[2] = { false, false };
-	bool ignore_s[2] = { false, false };
-
-	for (int i = 0; i < 2; i++) {
-		if (safes.Contains(idx[i]))
-			safe_s[i] = true;
-		if (ignores.Contains(idx[i]))
-			ignore_s[i] = true;
-	}
-
-	if ((safe_s[0] && ignore_s[0]) || (safe_s[1] && ignore_s[1]))
-		return;
-	if ((safe_s[0] && ignore_s[1]) || (ignore_s[0] && safe_s[1]) || (ignore_s[0] && ignore_s[1]))
-		return;
-
-	if (safe_s[0] && safe_s[1]) {
-		safes.Remove(idx[1]);
-		ignores.Emplace(idx[1]);
-		return;
-	}
-
-	for (int i = 0; i < 2; i++)
-	{
-		if (safe_s[i]) {
-			ignores.Emplace(idx[i]);
-			return;
-		}
-		if (ignore_s[i]) {
-			safes.Emplace(idx[i]);
-			return;
-		}
-	}
-
-	ignores.Emplace(idx[0]);
-	safes.Emplace(idx[1]);
-	return;		
-}
-
-bool ASimpleVoxel::CheckIgTri(int a, int b)
-{
-	int idx = -1;
-
-	for (int i = 0; i < 2; i++) {
-		for (int j = 0; j < 2; j++) {
-			if (segs[a].vert[i] == segs[b].vert[j]) {
-				idx = (segs[a].idx[(i + 1) % 2] < segs[b].idx[(j + 1) % 2])?
-					   SegFromI(segs[a].idx[(i + 1) % 2], segs[b].idx[(j + 1) % 2]):
-					   SegFromI(segs[b].idx[(j + 1) % 2], segs[a].idx[(i + 1) % 2]);
-			}
-		}
-	}
-
-	if (idx == -1 || idx <= b)
-		return false;
-
-	if (ignores.Contains(idx))
-		return true;
-
-	return false;
-}
-
 int ASimpleVoxel::SegFromI(int a, int b)
 {
-	return a*num_v - a*(a + 1) / 2 + b - (a + 1);
+	return SegFromI(a, b, num_v);
 }
 
 int ASimpleVoxel::SegFromI(int a, int b, int n)
@@ -127,7 +67,11 @@ int ASimpleVoxel::SegFromI(int a, int b, int n)
 //a < b < c
 //Indexes linear array of triangles from the three points defining the triangle
 int ASimpleVoxel::TriFromI(int a, int b, int c) {
-	return ((num_v - 2)*(num_v - 1)*num_v - (num_v - 2 - a)*(num_v - 1 - a)*(num_v - a)) / 6 + ((num_v - 2 - a)*(num_v - 1 - a) - (num_v - 1 - b)*(num_v - b)) / 2 + c - (b + 1);
+	return TriFromI(a, b, c, num_v);
+}
+
+int ASimpleVoxel::TriFromI(int a, int b, int c, int n) {
+	return ((n - 2)*(n - 1)*n - (n - 2 - a)*(n - 1 - a)*(n - a)) / 6 + ((n - 2 - a)*(n - 1 - a) - (n - 1 - b)*(n - b)) / 2 + c - (b + 1);
 }
 
 TArray<int32> ASimpleVoxel::GetTris()
@@ -149,8 +93,10 @@ TArray<int32> ASimpleVoxel::GetTris()
 	for (int i = 0; i < num_v; i++) {
 		for (int j = i + 1; j < num_v; j++) {
 			for (int k = j + 1; k < num_v; k++) {
-				if (checked_tri[TriFromI(i, j, k)])
+				if (checked_tri[TriFromI(i, j, k)]) {
+					//UE_LOG(LogTemp, Warning, TEXT("Skipping %d %d %d"), i, j, k);
 					continue;
+				}
 
 				pos = neg = false;
 				in_plane.Empty();
@@ -161,12 +107,14 @@ TArray<int32> ASimpleVoxel::GetTris()
 					if (l == i || l == j || l == k)
 						continue;
 					res = FVector::PointPlaneDist(verts[l], verts[i], p_norm);
-					if (FMath::Abs(res) < .0001)
+					if (FMath::Abs(res) < 1)
 						in_plane.Emplace(l);
 					else if (res >= 0) pos = true;
 					else if (res < 0) neg = true;
 
 				}
+
+				in_plane.Sort();
 				
 				for (int l = 0; l < in_plane.Num(); l++) {
 					for (int m = l + 1; m < in_plane.Num(); m++) {
@@ -177,11 +125,15 @@ TArray<int32> ASimpleVoxel::GetTris()
 				}
 
 				if (pos && neg) {
-					UE_LOG(LogTemp, Warning, TEXT("Pos and neg true! %d %d %d"), i, j, k);
+					//UE_LOG(LogTemp, Warning, TEXT("Pos and neg true! %d %d %d"), i, j, k);
 					continue;
 				}
 
-				ret_tris.Append(PlaneTris(in_plane));
+				UE_LOG(LogTemp, Warning, TEXT("Generating triangles for %d %d %d"), i, j, k);
+				for (int i : in_plane)
+					UE_LOG(LogTemp, Warning, TEXT("%d"), i);
+
+				ret_tris.Append(SimpleTris(in_plane));
 				
 
 			}
@@ -191,68 +143,24 @@ TArray<int32> ASimpleVoxel::GetTris()
 	return ret_tris;
 }
 
-TArray<int32> ASimpleVoxel::PlaneTris(TArray<int> points) {
-
-	Seg_3 seg_tmp;
-	int num_s;
-
+TArray<int32> ASimpleVoxel::SimpleTris(TArray<int> points) {
 	TArray<int32> ret;
 
-	ignores.Empty();
-	safes.Empty();
-	segs.Empty();
+	//First, second distances
+	float f_dist, s_dist;
 
-	points.Sort();
-
-	num_s = points.Num()*(points.Num() - 1) / 2;
-
-	for (int i = 0; i < points.Num(); i++) {
-		for (int j = i + 1; j < points.Num(); j++) {
-			for (int k = 0, vfs[2] = { i, j }; k < 2; k++) {
-				seg_tmp.vert[k] = verts[points[vfs[k]]];
-				seg_tmp.idx[k] = points[vfs[k]];
-			}
-			segs.Emplace(seg_tmp);
-		}
-	}
-
-	for (int i = 0; i < num_s; i++) {
-		for (int j = i + 1; j < num_s; j++) {
-			if (Overlap(segs[i], segs[j])) {
-				ResolveOverlap(i, j);
-			}
-		}
-	}
-
-	UE_LOG(LogTemp, Warning, TEXT("Ignore:"));
-	for (int ignore : ignores)
-		UE_LOG(LogTemp, Warning, TEXT("%d (%d %d)"), ignore, segs[ignore].idx[0], segs[ignore].idx[1]);
-
-	for (int i = 0; i < points.Num(); i++) {
-		for (int j = i + 1; j < points.Num(); j++) {
-			if (ignores.Contains(SegFromI(i, j, points.Num()))) {
-				UE_LOG(LogTemp, Warning, TEXT("Ignoring %d %d (%d)"), points[i], points[j], SegFromI(i, j, points.Num()));
-				continue;
-			}
-			for (int k = j + 1; k < points.Num(); k++) {
-				if (ignores.Contains(SegFromI(i, k, points.Num()))){
-					UE_LOG(LogTemp, Warning, TEXT("Ignoring %d %d (%d)"), points[i], points[k], SegFromI(i, k, points.Num()));
-					continue;
-				}
-				if (ignores.Contains(SegFromI(j, k, points.Num()))) {
-					UE_LOG(LogTemp, Warning, TEXT("Ignoring %d %d (%d)"), points[j], points[k], SegFromI(j, k, points.Num()));
-					continue;
-				}
-
-				UE_LOG(LogTemp, Warning, TEXT("Adding %d %d %d"), points[i], points[j], points[k]);
-				ret.Append({ points[i], points[j], points[k], points[k], points[j], points[i] });
-			}
-		}
+	while (points.Num() >= 3) {
+		UE_LOG(LogTemp, Warning, TEXT("Adding tri %d %d %d"), points[0], points[1], points[2]);
+		ret.Append({ points[0], points[1], points[2], points[2], points[1], points[0] });
+		f_dist = (sort_verts[points[1]] - sort_verts[points[0]]).Size() + (sort_verts[points[2]] - sort_verts[points[0]]).Size();
+		s_dist = (sort_verts[points[0]] - sort_verts[points[1]]).Size() + (sort_verts[points[2]] - sort_verts[points[1]]).Size();
+		if (f_dist < s_dist)
+			points.RemoveAt(0);
+		else
+			points.RemoveAt(1);
 	}
 
 	return ret;
-
-
 }
 
 TArray<FVector2D> ASimpleVoxel::GetUV(TArray<FVector> pos, FVector2D center, FVector2D uv_range, FVector2D point_range)
@@ -321,7 +229,7 @@ void ASimpleVoxel::Tick(float DeltaTime)
 	new_verts.Append(voxel.verts);
 	time += DeltaTime;
 
-	if (mesh_made) {
+	/*if (mesh_made) {
 		for (int i = 0; i < voxel.verts.Num(); i++) {
 			new_verts[i] = FMath::InterpSinInOut(voxel.verts[i], 2 * voxel.verts[i], abs(sinf(time)));
 		}
@@ -333,5 +241,6 @@ void ASimpleVoxel::Tick(float DeltaTime)
 		//		mesh->AddCollisionConvexMesh(new_verts);
 
 	}
+	*/
 }
 

--- a/Source/VoxelActors/SimpleVoxel.h
+++ b/Source/VoxelActors/SimpleVoxel.h
@@ -48,27 +48,26 @@ protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-	bool Overlap(Seg_3 seg1, Seg_3 seg2);
-	void ResolveOverlap(int a, int b);
-	bool CheckIgTri(int a, int b);
 	int SegFromI(int a, int b);
 	int SegFromI(int a, int b, int n);
 	int TriFromI(int a, int b, int c);
-	TArray<int32> PlaneTris(TArray<int> points);
-
-	TArray<FVector> verts;
-	TArray<int> safes, ignores;
-	TArray<Seg_3> segs;
-	int num_v;
-	bool mesh_made;
+	int TriFromI(int a, int b, int c, int n);
 
 	TArray<int32> GetTris();
+	TArray<int32> SimpleTris(TArray<int> points);
+
 	TArray<FVector2D> GetUV(TArray<FVector> pos, FVector2D center, FVector2D uv_range, FVector2D point_range);
 	TArray<FVector> GetNormals();
 	TArray<FProcMeshTangent> GetTangents();
 	TArray<FLinearColor> GetColors();
 	
 	void CreateVoxel(FVector2D uv_center);
+	
+	TArray<FVector> verts;
+	TArray<FVector> sort_verts;
+	int num_v;
+	bool mesh_made;
+
 
 public:	
 	// Called every frame


### PR DESCRIPTION
Main changes:

-Only works for convex polyhedra
-Eliminates extra triangles by using planes instead of the overlap code
--Makes sure all the points in a plane are on the plane, or on one side of the plane, that way it's an outer face
-Actually sorts the points when they're put in
--Points are sorted by distance from the origin after being translated so that all the points are above (0,0,0)
-Triangle selection from the plane points is done by just taking the first three points, removing a point, taking the first three points again, removing a point, so on and so forth
--Removal of the point: Either the first or second point is removed. Remove the one with the shortest distances to the other points (IE: If distance from 1-2+1-3 is less than 2-1+2-3, remove pt 1) as it is enveloped? by the other points. Now that I look at it, it's possible that I only need to check 1-3 and 2-3.

This completely supercedes the "simple" branch